### PR TITLE
Add logs command and attach rename

### DIFF
--- a/cmd/cli/commands/attach.go
+++ b/cmd/cli/commands/attach.go
@@ -1,0 +1,90 @@
+package commands
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+
+	"golang.org/x/term"
+
+	dockerContainer "github.com/docker/docker/api/types/container"
+
+	"Daemon/cmd/cli"
+	"Daemon/internal/docker"
+	"Daemon/internal/shared/logger"
+)
+
+func init() {
+	cli.RegisterCommand(&cli.Command{
+		Name:        "attach",
+		Description: "Attach to container's console (live logs + command input)",
+		Args: []cli.ArgSpec{
+			{Name: "containerName", Required: true},
+		},
+		Execute: runAttach,
+	})
+}
+
+func runAttach(command *cli.CommandContext) error {
+	name := command.Args[0]
+
+	// Create Docker client
+	client, err := docker.NewDockerClient()
+	if err != nil {
+		return logger.Error("Failed to initialize Docker client: %v", err)
+	}
+
+	// Resolve Docker container ID
+	id, err := client.ResolveNameToID(command.Ctx, name)
+	if err != nil {
+		return logger.Error("Container not found: %v", err)
+	}
+
+	// Attach to the container
+	attachResp, err := client.GetClient().ContainerAttach(command.Ctx, id, dockerContainer.AttachOptions{
+		Stream: true,
+		Stdin:  true,
+		Stdout: true,
+		Stderr: true,
+		Logs:   true,
+	})
+	if err != nil {
+		return logger.Error("Failed to attach: %v", err)
+	}
+	defer attachResp.Close()
+
+	// Check terminal
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		return logger.Error("stdin is not a terminal — cannot enter raw mode")
+	}
+
+	// Enter raw mode
+	oldState, err := term.MakeRaw(int(os.Stdin.Fd()))
+	if err != nil {
+		return logger.Error("Failed to set terminal raw mode: %v", err)
+	}
+	defer term.Restore(int(os.Stdin.Fd()), oldState)
+
+	fmt.Println("🖥️  Attached to container. Type commands below. Press Ctrl+C to exit.\n")
+
+	// Signal handler
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, os.Interrupt)
+
+	// Pipe input
+	go func() {
+		_, _ = io.Copy(attachResp.Conn, os.Stdin)
+	}()
+
+	// Pipe output directly (TTY containers send raw stdout)
+	go func() {
+		_, _ = io.Copy(os.Stdout, attachResp.Reader)
+	}()
+
+	// Wait for Ctrl+C
+	<-sigs
+	fmt.Println("\n🛑 Exiting attach session.")
+
+	return nil
+}

--- a/cmd/cli/commands/exec.go
+++ b/cmd/cli/commands/exec.go
@@ -1,0 +1,27 @@
+package commands
+
+import (
+	"Daemon/cmd/cli"
+	"Daemon/internal/shared/logger"
+)
+
+func init() {
+	cli.RegisterCommand(&cli.Command{
+		Name:        "exec",
+		Description: "Run a command inside a container",
+		Args: []cli.ArgSpec{
+			{Name: "containerName", Required: true},
+			{Name: "cmd", Required: true},
+		},
+		Execute: runExec,
+	})
+}
+
+func runExec(c *cli.CommandContext) error {
+	if len(c.Args) < 2 {
+		return logger.Error("usage: exec <containerName> <command>")
+	}
+	name := c.Args[0]
+	cmd := c.Args[1:]
+	return c.Service.ExecCommand(c.Ctx, name, cmd)
+}

--- a/cmd/cli/commands/logs.go
+++ b/cmd/cli/commands/logs.go
@@ -1,90 +1,19 @@
 package commands
 
 import (
-	"fmt"
-	"io"
-	"os"
-	"os/signal"
-
-	"golang.org/x/term"
-
-	dockerContainer "github.com/docker/docker/api/types/container"
-
 	"Daemon/cmd/cli"
-	"Daemon/internal/docker"
-	"Daemon/internal/shared/logger"
 )
 
 func init() {
 	cli.RegisterCommand(&cli.Command{
 		Name:        "logs",
-		Description: "Attach to container's console (live logs + command input)",
-		Args: []cli.ArgSpec{
-			{Name: "containerName", Required: true},
-		},
-		Execute: runLogs,
+		Description: "Print container logs",
+		Args:        []cli.ArgSpec{{Name: "containerName", Required: true}},
+		Execute:     runLogs,
 	})
 }
 
-func runLogs(command *cli.CommandContext) error {
-	name := command.Args[0]
-
-	// Create Docker client
-	client, err := docker.NewDockerClient()
-	if err != nil {
-		return logger.Error("Failed to initialize Docker client: %v", err)
-	}
-
-	// Resolve Docker container ID
-	id, err := client.ResolveNameToID(command.Ctx, name)
-	if err != nil {
-		return logger.Error("Container not found: %v", err)
-	}
-
-	// Attach to the container
-	attachResp, err := client.GetClient().ContainerAttach(command.Ctx, id, dockerContainer.AttachOptions{
-		Stream: true,
-		Stdin:  true,
-		Stdout: true,
-		Stderr: true,
-		Logs:   true,
-	})
-	if err != nil {
-		return logger.Error("Failed to attach: %v", err)
-	}
-	defer attachResp.Close()
-
-	// Check terminal
-	if !term.IsTerminal(int(os.Stdin.Fd())) {
-		return logger.Error("stdin is not a terminal — cannot enter raw mode")
-	}
-
-	// Enter raw mode
-	oldState, err := term.MakeRaw(int(os.Stdin.Fd()))
-	if err != nil {
-		return logger.Error("Failed to set terminal raw mode: %v", err)
-	}
-	defer term.Restore(int(os.Stdin.Fd()), oldState)
-
-	fmt.Println("🖥️  Attached to container. Type commands below. Press Ctrl+C to exit.\n")
-
-	// Signal handler
-	sigs := make(chan os.Signal, 1)
-	signal.Notify(sigs, os.Interrupt)
-
-	// Pipe input
-	go func() {
-		_, _ = io.Copy(attachResp.Conn, os.Stdin)
-	}()
-
-	// Pipe output directly (TTY containers send raw stdout)
-	go func() {
-		_, _ = io.Copy(os.Stdout, attachResp.Reader)
-	}()
-
-	// Wait for Ctrl+C
-	<-sigs
-	fmt.Println("\n🛑 Exiting attach session.")
-
-	return nil
+func runLogs(c *cli.CommandContext) error {
+	name := c.Args[0]
+	return c.Service.StreamLogs(c.Ctx, name)
 }

--- a/internal/docker/interface.go
+++ b/internal/docker/interface.go
@@ -3,6 +3,7 @@ package docker
 import (
 	"context"
 	"github.com/docker/docker/api/types/container"
+	"io"
 )
 
 type Client interface {
@@ -20,4 +21,11 @@ type Client interface {
 	GetContainerByID(ctx context.Context, id string) (*container.InspectResponse, error)
 
 	ResolveNameToID(ctx context.Context, name string) (string, error)
+
+	// ExecInteractive runs a command inside the given container ID and
+	// attaches the current terminal for interactive input/output.
+	ExecInteractive(ctx context.Context, id string, cmd []string) error
+
+	// GetContainerLogs returns a reader for the container's logs.
+	GetContainerLogs(ctx context.Context, id string) (io.ReadCloser, error)
 }


### PR DESCRIPTION
## Summary
- rename old interactive logs command to `attach`
- implement new `logs` command to stream container logs
- expose logs streaming through container service and Docker client

## Testing
- `go test ./...` *(fails: proxy.golang.org blocked)`